### PR TITLE
Add backpressure samples

### DIFF
--- a/src/main/java/playground/grpc/backpressure/BackpressureStreamingServiceImpl.java
+++ b/src/main/java/playground/grpc/backpressure/BackpressureStreamingServiceImpl.java
@@ -1,0 +1,39 @@
+package playground.grpc.backpressure;
+
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import playground.grpc.StreamingRequest;
+import playground.grpc.StreamingResponse;
+import playground.grpc.StreamingServiceGrpc;
+
+/**
+ * Implementation of server streaming with implemented backpressure. Server checks if stream is ready to accept
+ * new message before sending them.
+ */
+public class BackpressureStreamingServiceImpl extends StreamingServiceGrpc.StreamingServiceImplBase {
+
+    @Override
+    public void streamingMethod(StreamingRequest request, StreamObserver<StreamingResponse> responseObserver) {
+        // Convert response observer to ServerCallStreamObserver, so we can access additional API
+        // for checking stream status
+        ServerCallStreamObserver<StreamingResponse> serverCallStreamObserver =
+                (ServerCallStreamObserver<StreamingResponse>) responseObserver;
+
+        // This handler will be called each time stream becomes ready and can accept new messages.
+        // Handler is executed in the same thread as service method, so we must return from it before
+        // this handler is actually executed
+        serverCallStreamObserver.setOnReadyHandler(new Runnable() {
+
+            private int counter;
+
+            @Override
+            public void run() {
+                // isReady() method doesn't return false immediatelly after client stops requesting more messages.
+                // There is still some amount of buffering but will produce OutOfMemoryError.
+                while (serverCallStreamObserver.isReady()) {
+                    responseObserver.onNext(StreamingResponse.newBuilder().setRandomId(counter++).build());
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/playground/grpc/backpressure/FailingStreaming.java
+++ b/src/main/java/playground/grpc/backpressure/FailingStreaming.java
@@ -1,0 +1,69 @@
+package playground.grpc.backpressure;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import lombok.SneakyThrows;
+import playground.grpc.StreamingRequest;
+import playground.grpc.StreamingResponse;
+import playground.grpc.StreamingServiceGrpc;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class FailingStreaming {
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+    private Server server;
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        FailingStreaming streamingServer = new FailingStreaming();
+        streamingServer.startServer();
+
+        EXECUTOR.execute(FailingStreaming::startClient);
+
+        streamingServer.blockUntilShutdown();
+    }
+
+    @SneakyThrows
+    private static void startClient() {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:50000").usePlaintext().build();
+        StreamingServiceGrpc.StreamingServiceBlockingStub blockingStub = StreamingServiceGrpc.newBlockingStub(channel);
+        try {
+            Iterator<StreamingResponse> responseIterator = blockingStub.streamingMethod(StreamingRequest.getDefaultInstance());
+            while (responseIterator.hasNext()) {
+                System.out.println(responseIterator.next().getRandomId());
+                Thread.sleep(1000);
+            }
+        } finally {
+            channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private void startServer() throws IOException {
+        server = ServerBuilder.forPort(50000).addService(new NoBackpressureStreamingServiceImpl()).build().start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                FailingStreaming.this.stopServer();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }));
+    }
+
+    private void stopServer() throws InterruptedException {
+        if (server != null) {
+            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private void blockUntilShutdown() throws InterruptedException {
+        if (server != null) {
+            server.awaitTermination();
+        }
+    }
+}

--- a/src/main/java/playground/grpc/backpressure/NoBackpressureStreamingServiceImpl.java
+++ b/src/main/java/playground/grpc/backpressure/NoBackpressureStreamingServiceImpl.java
@@ -1,0 +1,26 @@
+package playground.grpc.backpressure;
+
+import io.grpc.stub.StreamObserver;
+import playground.grpc.StreamingRequest;
+import playground.grpc.StreamingResponse;
+import playground.grpc.StreamingServiceGrpc;
+
+import java.util.Random;
+
+/**
+ * Implementation of server streaming with infinite production of random responses. Eventually this will
+ * produce {@link OutOfMemoryError} when client can't consumer stream fast enough. Server will buffer unsent
+ * responses until memory is full. Backpressure is not implemented because server doesn't check if stream is
+ * ready to accept new messages.
+ */
+public class NoBackpressureStreamingServiceImpl extends StreamingServiceGrpc.StreamingServiceImplBase {
+
+    private final Random random = new Random();
+
+    @Override
+    public void streamingMethod(StreamingRequest request, StreamObserver<StreamingResponse> responseObserver) {
+        while (true) {
+            responseObserver.onNext(StreamingResponse.newBuilder().setRandomId(random.nextInt()).build());
+        }
+    }
+}

--- a/src/main/java/playground/grpc/backpressure/SuccessfulStreaming.java
+++ b/src/main/java/playground/grpc/backpressure/SuccessfulStreaming.java
@@ -1,0 +1,86 @@
+package playground.grpc.backpressure;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import lombok.SneakyThrows;
+import playground.grpc.StreamingRequest;
+import playground.grpc.StreamingResponse;
+import playground.grpc.StreamingServiceGrpc;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class SuccessfulStreaming {
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+    private Server server;
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        SuccessfulStreaming streamingServer = new SuccessfulStreaming();
+        streamingServer.startServer();
+
+        EXECUTOR.execute(SuccessfulStreaming::startClient);
+
+        streamingServer.blockUntilShutdown();
+    }
+
+    @SneakyThrows
+    private static void startClient() {
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:50000").usePlaintext().build();
+        StreamingServiceGrpc.StreamingServiceStub stub = StreamingServiceGrpc.newStub(channel);
+
+        ClientResponseObserver<StreamingRequest, StreamingResponse> clientResponseObserver =
+                new ClientResponseObserver<>() {
+                    @Override
+                    public void beforeStart(ClientCallStreamObserver<StreamingRequest> requestStream) {
+                    }
+
+                    @SneakyThrows
+                    @Override
+                    public void onNext(StreamingResponse response) {
+                        System.out.println(response.getRandomId());
+                        Thread.sleep(500);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                    }
+                };
+
+        stub.streamingMethod(StreamingRequest.getDefaultInstance(), clientResponseObserver);
+    }
+
+    private void startServer() throws IOException {
+        server = ServerBuilder.forPort(50000).addService(new BackpressureStreamingServiceImpl()).build().start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                SuccessfulStreaming.this.stopServer();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }));
+    }
+
+    private void stopServer() throws InterruptedException {
+        if (server != null) {
+            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private void blockUntilShutdown() throws InterruptedException {
+        if (server != null) {
+            server.awaitTermination();
+        }
+    }
+}

--- a/src/main/proto/manualflowcontrol.proto
+++ b/src/main/proto/manualflowcontrol.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "playground.grpc";
+
+package playground.grpc;
+
+service StreamingService {
+  rpc StreamingMethod(StreamingRequest) returns (stream StreamingResponse);
+}
+
+message StreamingRequest {
+}
+
+message StreamingResponse {
+  int32 random_id = 1;
+}


### PR DESCRIPTION
- Added example without backpressure which fails with `OutOfMemoryError`
- Added example with backpressure (without manual flow control) which mitigates memory issues